### PR TITLE
Replace enableHapticFeedback with onCurrentXChange

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,12 +15,12 @@
     "bumbag": "^2.2.1",
     "bumbag-native": "^2.3.0",
     "expo": "42.0.1",
+    "expo-haptics": "^10.1.0",
     "expo-splash-screen": "~0.11.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "0.63.4",
     "react-native-gesture-handler": "~1.10.2",
-    "react-native-haptic-feedback": "^1.11.0",
     "react-native-reanimated": "~2.2.0",
     "react-native-unimodules": "~0.14.5",
     "react-native-web": "~0.13.12"

--- a/example/src/CandlestickChart.tsx
+++ b/example/src/CandlestickChart.tsx
@@ -5,6 +5,14 @@ import { CandlestickChart } from 'react-native-wagmi-charts';
 import mockData from './data/candlestick-data.json';
 import mockData2 from './data/candlestick-data2.json';
 
+import * as haptics from 'expo-haptics';
+
+function invokeHaptic(value: number) {
+  if (value !== 0) {
+    haptics.impactAsync(haptics.ImpactFeedbackStyle.Light);
+  }
+}
+
 export default function App() {
   const [data, setData] = React.useState<any>(mockData);
 
@@ -16,7 +24,7 @@ export default function App() {
       <CandlestickChart.Provider data={data}>
         <CandlestickChart>
           <CandlestickChart.Candles />
-          <CandlestickChart.Crosshair>
+          <CandlestickChart.Crosshair onCurrentXChange={invokeHaptic}>
             <CandlestickChart.Tooltip />
           </CandlestickChart.Crosshair>
         </CandlestickChart>

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5770,6 +5770,11 @@ expo-font@~9.2.1:
     expo-modules-core "~0.2.0"
     fontfaceobserver "^2.1.0"
 
+expo-haptics@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/expo-haptics/-/expo-haptics-10.1.0.tgz#2ef5f0c3442f57844f7a7a961d922872e4ea9a71"
+  integrity sha512-2rpixkP3LSCwaJAmbbs0CSqbY7lSk7Ytay4UAYWg3YiJ05My7+MGMPbQJARyAMI5JQNuzcdsZN74btSusBvgYQ==
+
 expo-image-loader@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-2.2.0.tgz#b5d49ec65e576c033823050b223ef462c5ec5711"
@@ -10798,11 +10803,6 @@ react-native-gesture-handler@~1.10.2:
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
     prop-types "^15.7.2"
-
-react-native-haptic-feedback@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-1.11.0.tgz#adfd841f3b67046532f912c6ec827aea0037d8ad"
-  integrity sha512-KTIy7lExwMtB6pOpCARyUzFj5EzYTh+A1GN/FB5Eb0LrW5C6hbb1kdj9K2/RHyZC+wyAJD1M823ZaDCU6n6cLA==
 
 react-native-reanimated@~2.2.0:
   version "2.2.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "react-native": "^0.64.2",
     "react-native-builder-bob": "^0.18.1",
     "react-native-gesture-handler": "^1.10.3",
-    "react-native-haptic-feedback": "^1.11.0",
     "react-native-reanimated": "^2.2.0",
     "typescript": "^4.3.5"
   },
@@ -67,7 +66,6 @@
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": "*",
-    "react-native-haptic-feedback": "*",
     "react-native-reanimated": "*"
   },
   "jest": {

--- a/src/charts/candle/Crosshair.tsx
+++ b/src/charts/candle/Crosshair.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { StyleSheet, ViewProps } from 'react-native';
-import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import {
   PanGestureHandler,
   PanGestureHandlerProps,
@@ -22,22 +21,15 @@ import { CandlestickChartCrosshairTooltipContext } from './CrosshairTooltip';
 type CandlestickChartCrosshairProps = PanGestureHandlerProps & {
   color?: string;
   children?: React.ReactNode;
-  enableHapticFeedback?: boolean;
+  onCurrentXChange?: (value: number) => unknown;
   horizontalCrosshairProps?: Animated.AnimateProps<ViewProps>;
   verticalCrosshairProps?: Animated.AnimateProps<ViewProps>;
   lineProps?: Partial<CandlestickChartLineProps>;
 };
 
-function invokeHaptic() {
-  ReactNativeHapticFeedback.trigger('impactLight', {
-    enableVibrateFallback: true,
-    ignoreAndroidSystemSettings: false,
-  });
-}
-
 export function CandlestickChartCrosshair({
   color,
-  enableHapticFeedback = false,
+  onCurrentXChange,
   children,
   horizontalCrosshairProps = {},
   verticalCrosshairProps = {},
@@ -78,10 +70,10 @@ export function CandlestickChartCrosshair({
   }));
 
   useAnimatedReaction(
-    () => (enableHapticFeedback ? currentX.value : 0),
+    () => currentX.value,
     (data) => {
-      if (data !== 0) {
-        runOnJS(invokeHaptic)();
+      if (onCurrentXChange) {
+        runOnJS(onCurrentXChange)(data);
       }
     }
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6215,11 +6215,6 @@ react-native-gesture-handler@^1.10.3:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-haptic-feedback@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-1.11.0.tgz#adfd841f3b67046532f912c6ec827aea0037d8ad"
-  integrity sha512-KTIy7lExwMtB6pOpCARyUzFj5EzYTh+A1GN/FB5Eb0LrW5C6hbb1kdj9K2/RHyZC+wyAJD1M823ZaDCU6n6cLA==
-
 react-native-reanimated@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.2.0.tgz#a6412c56b4e591d1f00fac949f62d0c72c357c78"


### PR DESCRIPTION
Removes dependency on react-native-haptic-feedback
Allows user to provide their own haptics implementation

Closes #3