### PR TITLE
Refactor typescript types

### DIFF
--- a/example/src/CandlestickChart.tsx
+++ b/example/src/CandlestickChart.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Box, Button, Flex, Heading, Text, Stack } from 'bumbag-native';
-import { CandlestickChart } from 'react-native-wagmi-charts';
+import { CandlestickChart, TCandle } from 'react-native-wagmi-charts';
 import * as haptics from 'expo-haptics';
 
 import mockData from './data/candlestick-data.json';
@@ -11,7 +11,7 @@ function invokeHaptic() {
 }
 
 export default function App() {
-  const [data, setData] = React.useState<any>(mockData);
+  const [data, setData] = React.useState<TCandle[]>(mockData);
 
   return (
     <>
@@ -92,7 +92,7 @@ export default function App() {
               <Box flex="1">
                 <Text fontSize="100">Current</Text>
                 <CandlestickChart.PriceText
-                  format={(d: any) => {
+                  format={(d) => {
                     'worklet';
                     return `$${d.formatted} AUD`;
                   }}
@@ -102,7 +102,7 @@ export default function App() {
                 <Text fontSize="100">Open</Text>
                 <CandlestickChart.PriceText
                   type="open"
-                  format={(d: any) => {
+                  format={(d) => {
                     'worklet';
                     return `$${d.formatted} AUD`;
                   }}
@@ -112,7 +112,7 @@ export default function App() {
                 <Text fontSize="100">Close</Text>
                 <CandlestickChart.PriceText
                   type="close"
-                  format={(d: any) => {
+                  format={(d) => {
                     'worklet';
                     return `$${d.formatted} AUD`;
                   }}

--- a/example/src/LineChart.tsx
+++ b/example/src/LineChart.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Box, Button, Flex, Heading, Stack, Text } from 'bumbag-native';
-import { LineChart } from 'react-native-wagmi-charts';
+import { LineChart, TLineChartPoint } from 'react-native-wagmi-charts';
 import * as haptics from 'expo-haptics';
 
 import mockData from './data/line-data.json';
@@ -11,7 +11,7 @@ function invokeHaptic() {
 }
 
 export default function App() {
-  const [data, setData] = React.useState<any>(mockData);
+  const [data, setData] = React.useState<TLineChartPoint[]>(mockData);
 
   return (
     <>
@@ -82,7 +82,7 @@ export default function App() {
           <Flex>
             <Text fontWeight="500">Custom format: </Text>
             <LineChart.PriceText
-              format={(d: any) => {
+              format={(d) => {
                 'worklet';
                 return `$${d.formatted} AUD`;
               }}

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
           "trailingComma": "es5",
           "useTabs": false
         }
-      ]
+      ],
+      "@typescript-eslint/no-explicit-any": "error"
     }
   },
   "eslintIgnore": [

--- a/src/charts/candle/Crosshair.tsx
+++ b/src/charts/candle/Crosshair.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { StyleSheet, ViewProps } from 'react-native';
 import {
+  GestureEvent,
   LongPressGestureHandler,
+  LongPressGestureHandlerEventPayload,
   LongPressGestureHandlerProps,
 } from 'react-native-gesture-handler';
 import Animated, {
@@ -42,7 +44,9 @@ export function CandlestickChartCrosshair({
   const tooltipPosition = useSharedValue<'left' | 'right'>('left');
 
   const opacity = useSharedValue(0);
-  const onGestureEvent = useAnimatedGestureHandler({
+  const onGestureEvent = useAnimatedGestureHandler<
+    GestureEvent<LongPressGestureHandlerEventPayload>
+  >({
     onActive: ({ x, y }) => {
       const boundedX = x <= width - 1 ? x : width - 1;
       if (boundedX < 100) {
@@ -81,7 +85,7 @@ export function CandlestickChartCrosshair({
   return (
     <LongPressGestureHandler
       minDurationMs={0}
-      onGestureEvent={onGestureEvent as any}
+      onGestureEvent={onGestureEvent}
       {...props}
     >
       <Animated.View style={StyleSheet.absoluteFill}>

--- a/src/charts/candle/DatetimeText.tsx
+++ b/src/charts/candle/DatetimeText.tsx
@@ -4,11 +4,12 @@ import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 
 import { useCandlestickChartDatetime } from './useDatetime';
+import type { TFormatterFn } from 'react-native-wagmi-charts';
 
 type CandlestickChartPriceTextProps = {
   locale?: string;
   options?: { [key: string]: string };
-  format?: any;
+  format?: TFormatterFn<number>;
   variant?: 'formatted' | 'value';
   style?: Animated.AnimateProps<RNTextProps>['style'];
 };

--- a/src/charts/candle/Line.tsx
+++ b/src/charts/candle/Line.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import Svg, { Line as SVGLine, LineProps } from 'react-native-svg';
 
-export type CandlestickChartLineProps = LineProps & {
+export type CandlestickChartLineProps = Omit<LineProps, 'x' | 'y'> & {
   color?: string;
   x: number;
   y: number;

--- a/src/charts/candle/PriceText.tsx
+++ b/src/charts/candle/PriceText.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { ReText } from 'react-native-redash';
 import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
-import type { TPriceType } from './types';
+import type { TFormatterFn, TPriceType } from './types';
 
 import { useCandlestickChartPrice } from './usePrice';
 
 export type CandlestickChartPriceTextProps = {
-  format?: any;
+  format?: TFormatterFn<string>;
   precision?: number;
   variant?: 'formatted' | 'value';
   type?: TPriceType;

--- a/src/charts/candle/types.ts
+++ b/src/charts/candle/types.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import type Animated from 'react-native-reanimated';
 
 export type TCandle = {
@@ -8,7 +9,7 @@ export type TCandle = {
   close: number;
 };
 export type TData = Array<TCandle>;
-export type TDomain = [number, number];
+export type TDomain = [min: number, max: number];
 export type TContext = {
   currentX: Animated.SharedValue<number>;
   currentY: Animated.SharedValue<number>;
@@ -17,7 +18,14 @@ export type TContext = {
   height: number;
   domain: TDomain;
   step: number;
-  setWidth: any;
-  setHeight: any;
+  setWidth: React.Dispatch<React.SetStateAction<number>>;
+  setHeight: React.Dispatch<React.SetStateAction<number>>;
 };
 export type TPriceType = 'crosshair' | 'open' | 'close' | 'low' | 'high';
+export type TFormatterFn<T> = ({
+  value,
+  formatted,
+}: {
+  value: T;
+  formatted: string;
+}) => string;

--- a/src/charts/candle/useCandleData.ts
+++ b/src/charts/candle/useCandleData.ts
@@ -1,8 +1,9 @@
-import { useDerivedValue } from 'react-native-reanimated';
+import Animated, { useDerivedValue } from 'react-native-reanimated';
+import type { TCandle } from './types';
 
 import { useCandlestickChart } from './useCandlestickChart';
 
-export function useCandleData() {
+export function useCandleData(): Readonly<Animated.SharedValue<TCandle>> {
   const { currentX, data, step } = useCandlestickChart();
 
   const candle = useDerivedValue(() => {

--- a/src/charts/candle/useCandlestickChart.ts
+++ b/src/charts/candle/useCandlestickChart.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
 import { CandlestickChartContext } from './Context';
+import type { TContext } from './types';
 
-export function useCandlestickChart() {
+export function useCandlestickChart(): TContext {
   return React.useContext(CandlestickChartContext);
 }

--- a/src/charts/candle/useDatetime.ts
+++ b/src/charts/candle/useDatetime.ts
@@ -1,6 +1,7 @@
-import { useDerivedValue } from 'react-native-reanimated';
+import Animated, { useDerivedValue } from 'react-native-reanimated';
 
 import { formatDatetime } from '../../utils';
+import type { TFormatterFn } from './types';
 import { useCandleData } from './useCandleData';
 
 export function useCandlestickChartDatetime({
@@ -8,10 +9,13 @@ export function useCandlestickChartDatetime({
   locale,
   options,
 }: {
-  format?: any;
+  format?: TFormatterFn<number>;
   locale?: string;
   options?: { [key: string]: string };
-} = {}) {
+} = {}): {
+  value: Readonly<Animated.SharedValue<string>>;
+  formatted: Readonly<Animated.SharedValue<string>>;
+} {
   const candle = useCandleData();
 
   const timestamp = useDerivedValue(() => {

--- a/src/charts/candle/usePrice.ts
+++ b/src/charts/candle/usePrice.ts
@@ -1,16 +1,23 @@
-import { useDerivedValue } from 'react-native-reanimated';
+import Animated, { useDerivedValue } from 'react-native-reanimated';
 
 import { formatPrice } from '../../utils';
 import { useCandlestickChart } from './useCandlestickChart';
 import { getPrice } from './utils';
-import type { TPriceType } from './types';
+import type { TFormatterFn, TPriceType } from './types';
 import { useCandleData } from './useCandleData';
 
 export function useCandlestickChartPrice({
   format,
   precision = 2,
   type = 'crosshair',
-}: { format?: any; precision?: number; type?: TPriceType } = {}) {
+}: {
+  format?: TFormatterFn<string>;
+  precision?: number;
+  type?: TPriceType;
+} = {}): {
+  value: Readonly<Animated.SharedValue<string>>;
+  formatted: Readonly<Animated.SharedValue<string>>;
+} {
   const { currentY, domain, height } = useCandlestickChart();
   const candle = useCandleData();
 

--- a/src/charts/candle/utils.ts
+++ b/src/charts/candle/utils.ts
@@ -2,7 +2,7 @@ import { interpolate, Extrapolate } from 'react-native-reanimated';
 
 import type { TCandle, TDomain } from './types';
 
-export function getDomain(rows: TCandle[]): [number, number] {
+export function getDomain(rows: TCandle[]): [min: number, max: number] {
   'worklet';
   const values = rows.map(({ high, low }) => [high, low]).flat();
   const min = Math.min(...values);

--- a/src/charts/line/Chart.tsx
+++ b/src/charts/line/Chart.tsx
@@ -16,7 +16,7 @@ type LineChartProps = ViewProps & {
   yGutter?: number;
   width?: number;
   height?: number;
-  shape?: any;
+  shape?: string;
 };
 
 const { width: screenWidth } = Dimensions.get('window');

--- a/src/charts/line/Cursor.tsx
+++ b/src/charts/line/Cursor.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { StyleSheet } from 'react-native';
 import {
+  GestureEvent,
   LongPressGestureHandler,
+  LongPressGestureHandlerEventPayload,
   LongPressGestureHandlerProps,
 } from 'react-native-gesture-handler';
 import Animated, { useAnimatedGestureHandler } from 'react-native-reanimated';
@@ -30,7 +32,9 @@ export function LineChartCursor({
     [path]
   );
 
-  const onGestureEvent = useAnimatedGestureHandler({
+  const onGestureEvent = useAnimatedGestureHandler<
+    GestureEvent<LongPressGestureHandlerEventPayload>
+  >({
     onActive: ({ x }) => {
       if (parsedPath) {
         const boundedX = x <= width ? x : width;
@@ -52,7 +56,7 @@ export function LineChartCursor({
     <CursorContext.Provider value={{ type }}>
       <LongPressGestureHandler
         minDurationMs={0}
-        onGestureEvent={onGestureEvent as any}
+        onGestureEvent={onGestureEvent}
         {...props}
       >
         <Animated.View style={StyleSheet.absoluteFill}>

--- a/src/charts/line/DatetimeText.tsx
+++ b/src/charts/line/DatetimeText.tsx
@@ -4,11 +4,12 @@ import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 
 import { useLineChartDatetime } from './useDatetime';
+import type { TFormatterFn } from 'react-native-wagmi-charts';
 
-type LineChartPriceTextProps = {
+type LineChartDatetimeProps = {
   locale?: string;
-  options?: { [key: string]: any };
-  format?: any;
+  options?: Intl.DateTimeFormatOptions;
+  format?: TFormatterFn<number>;
   variant?: 'formatted' | 'value';
   style?: Animated.AnimateProps<RNTextProps>['style'];
 };
@@ -19,7 +20,7 @@ export function LineChartDatetimeText({
   format,
   variant = 'formatted',
   ...props
-}: LineChartPriceTextProps) {
+}: LineChartDatetimeProps) {
   const datetime = useLineChartDatetime({ format, locale, options });
   return <ReText text={datetime[variant]} {...props} />;
 }

--- a/src/charts/line/PriceText.tsx
+++ b/src/charts/line/PriceText.tsx
@@ -4,9 +4,10 @@ import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 
 import { useLineChartPrice } from './usePrice';
+import type { TFormatterFn } from '../candle/types';
 
 export type LineChartPriceTextProps = {
-  format?: any;
+  format?: TFormatterFn<string>;
   precision?: number;
   variant?: 'formatted' | 'value';
   style?: Animated.AnimateProps<RNTextProps>['style'];

--- a/src/charts/line/useDatetime.ts
+++ b/src/charts/line/useDatetime.ts
@@ -1,6 +1,7 @@
 import { useDerivedValue } from 'react-native-reanimated';
 
 import { formatDatetime } from '../../utils';
+import type { TFormatterFn } from '../candle/types';
 import { useLineChart } from './useLineChart';
 
 export function useLineChartDatetime({
@@ -8,9 +9,9 @@ export function useLineChartDatetime({
   locale,
   options,
 }: {
-  format?: any;
+  format?: TFormatterFn<number>;
   locale?: string;
-  options?: { [key: string]: string };
+  options?: Intl.DateTimeFormatOptions;
 } = {}) {
   const { currentIndex, data } = useLineChart();
 

--- a/src/charts/line/usePrice.ts
+++ b/src/charts/line/usePrice.ts
@@ -1,12 +1,13 @@
 import { useDerivedValue } from 'react-native-reanimated';
 
 import { formatPrice } from '../../utils';
+import type { TFormatterFn } from '../candle/types';
 import { useLineChart } from './useLineChart';
 
 export function useLineChartPrice({
   format,
   precision = 2,
-}: { format?: any; precision?: number } = {}) {
+}: { format?: TFormatterFn<string>; precision?: number } = {}) {
   const { currentIndex, data } = useLineChart();
 
   const float = useDerivedValue(() => {

--- a/src/charts/line/utils.ts
+++ b/src/charts/line/utils.ts
@@ -34,8 +34,8 @@ export function getPath({
     .range([height - gutter, gutter]);
   const path = shape
     .line()
-    .x((_: any, i: number) => scaleX(i))
-    .y((data: any) => scaleY(data.value))
+    .x((_: unknown, i: number) => scaleX(i))
+    .y((d: { value: unknown }) => scaleY(d.value))
     .curve(_shape)(data);
   return path;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,17 +45,17 @@ export function formatDatetime({
 }: {
   value: number;
   locale?: string;
-  options?: { [key: string]: string };
+  options?: Intl.DateTimeFormatOptions;
 }) {
   'worklet';
   const d = new Date(value);
   return d.toLocaleString(locale, options);
 }
 
-export function usePrevious(value: any) {
+export function usePrevious<T>(value: T) {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
-  const ref = React.useRef();
+  const ref = React.useRef<T>();
   // Store current value in ref
   React.useEffect(() => {
     ref.current = value;


### PR DESCRIPTION
The final goal is to generate the API section in the README automatically based on the code via JSDoc, instead of having to maintain it manually.

While trying to work on that, I noticed that the usage of typescript could be improved in various places.

Hope this is ok :)