### PR TITLE
Update utils.ts

### DIFF
--- a/src/charts/line/utils.ts
+++ b/src/charts/line/utils.ts
@@ -7,7 +7,7 @@ import type { TLineChartData, TLineChartPoint } from './types';
 
 export function getDomain(rows: TLineChartPoint[]): [number, number] {
   'worklet';
-  const values = rows.map(({ value }) => [value]).flat();
+  const values = rows.map(({ value }) => value);
   return [Math.min(...values), Math.max(...values)];
 }
 


### PR DESCRIPTION
Tiny speed upgrade for `getDomain`. FWIW, I've seen the reanimated team recommend using standard `for (let i = 0, ...)` loops on the native thread on their PRs, stating that they're faster. Not trying to overoptimize, but figured I'd mention it.