### PR TITLE
[Web] Fix `AnimatedText` style

### DIFF
--- a/src/components/AnimatedText.tsx
+++ b/src/components/AnimatedText.tsx
@@ -29,6 +29,7 @@ export const AnimatedText = ({ text, style }: AnimatedTextProps) => {
       if (Platform.OS === 'web' && data !== prevData && inputRef.current) {
         inputRef.current.setNativeProps({
           value: data,
+          style
         });
       }
     }


### PR DESCRIPTION
Changing the `text.value` sometimes clears the `style` on web. Oddly, it only happens in prod builds. `setNativeText` is super finicky, but this seems to solve it. I'll keep testing to be sure.