### PR TITLE
[Web] Fix `LineChart.Dot`

### DIFF
--- a/src/charts/line/Dot.tsx
+++ b/src/charts/line/Dot.tsx
@@ -10,7 +10,7 @@ import Animated, {
 import { View } from 'react-native';
 import { getYForX, parse } from 'react-native-redash';
 import { useMemo } from 'react';
-import { StyleSheet } from 'react-native'
+import { StyleSheet } from 'react-native';
 
 import { LineChartDimensionsContext } from './Chart';
 import { useLineChart } from './useLineChart';

--- a/src/charts/line/Dot.tsx
+++ b/src/charts/line/Dot.tsx
@@ -10,6 +10,7 @@ import Animated, {
 import { View } from 'react-native';
 import { getYForX, parse } from 'react-native-redash';
 import { useMemo } from 'react';
+import { StyleSheet } from 'react-native'
 
 import { LineChartDimensionsContext } from './Chart';
 import { useLineChart } from './useLineChart';
@@ -130,11 +131,10 @@ export function LineChartDot({
       pointerEvents="none"
       style={useMemo(
         () => [
+          styles.container,
           {
             width: outerSize,
             height: outerSize,
-            alignItems: 'center',
-            justifyContent: 'center',
           },
           containerStyle,
         ],
@@ -176,3 +176,13 @@ export function LineChartDot({
     </Animated.View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+  }
+})


### PR DESCRIPTION
Adds `position: absolute` to the `Dot` component. This was already implicit in its usage, but was required to work on Web. It also won't work on Web if it's nested inside of `Svg` (which happens if it's inside of `Path`.