### PR TITLE
feat: static labels/tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A sweet & simple chart library for React Native that will make us feel like **W*
   - [Interactive cursors](#interactive-cursors)
   - [Interactive labels](#interactive-labels)
   - [Interactive tooltips](#interactive-tooltips)
+  - [Tooltips / labels](#tooltips--labels)
   - [Haptic feedback](#haptic-feedback)
   - [Colors](#colors)
   - [Gradients](#gradients)
@@ -281,6 +282,23 @@ You can even add another tooltip to show something like date/time:
 ```
 
 <img src="https://user-images.githubusercontent.com/7336481/133036011-8a9b4865-10dd-4e88-9fd1-1e109435a73c.gif" width="200px" />
+
+### Tooltips / Labels
+
+You can also use the `Tooltip` component to render a "static" tooltip at a given index, by specifying the `at` prop (similar to [Dots](#dots)).
+Note that the tooltip will disappear when there is interaction with a cursor on the chart.
+
+```jsx
+<LineChart.Provider data={data}>
+  <LineChart>
+    <LineChart.Path>
+      <LineChart.Tooltip at={3} />
+    </LineChart.Path>
+  </LineChart>
+</LineChart.Provider>
+```
+
+<img src="https://user-images.githubusercontent.com/16821682/157064279-c0923a60-edf8-4942-a029-0145dd225d3f.gif" width="200px" />
 
 ### Haptic feedback
 
@@ -881,12 +899,13 @@ To customize the formatting of the date/time text, you can supply a `format` fun
 
 ### LineChart.Tooltip
 
-| Prop           | Type                  | Default | Description                                          |
-| -------------- | --------------------- | ------- | ---------------------------------------------------- |
-| `xGutter`      | `number`              | `8`     | X axis gutter in which the tooltip will not pass.    |
-| `yGutter`      | `number`              | `8`     | Y axis gutter in which the tooltip will not pass.    |
-| `cursorGutter` | `number`              | `48`    | Gutter (spacing) between the cursor and the tooltip. |
-| `position`     | `"top"` or `"bottom"` | `"top"` | Position of the tooltip relative to the cursor.      |
+| Prop           | Type                  | Default | Description                                                                                                                    |
+|----------------|-----------------------|---------|--------------------------------------------------------------------------------------------------------------------------------|
+| `xGutter`      | `number`              | `8`     | X axis gutter in which the tooltip will not pass.                                                                              |
+| `yGutter`      | `number`              | `8`     | Y axis gutter in which the tooltip will not pass.                                                                              |
+| `cursorGutter` | `number`              | `48`    | Gutter (spacing) between the cursor and the tooltip.                                                                           |
+| `position`     | `"top"` or `"bottom"` | `"top"` | Position of the tooltip relative to the cursor.                                                                                |
+| `at`           | `number`              |         | Make the tooltip static at the given `data` index (which shows the tooltip always, unless there is interaction with the chart) |
 
 ### LineChart.PriceText
 
@@ -1044,9 +1063,10 @@ const { value, formatted } = LineChart.usePrice({
 **Arguments**
 
 | Variable    | Type                               | Default | Description                          |
-| ----------- | ---------------------------------- | ------- | ------------------------------------ |
+| ----------- |------------------------------------|---------|--------------------------------------|
 | `format`    | `({ value, formatted }) => string` |         | Custom format function of the price. |
 | `precision` | `number`                           | `2`     | Precision of the price value.        |
+| `index`     | `number`                           |         | Get the price for a specific index   |
 
 **Returns**
 

--- a/example/src/LineChart.tsx
+++ b/example/src/LineChart.tsx
@@ -66,9 +66,7 @@ export default function App() {
       {!toggleMinMaxLabels && <LineChart.Path color="black" />}
       {toggleMinMaxLabels && (
         <LineChart.Path color="black">
-          <LineChart.Dot color="green" at={max} />
           <LineChart.Tooltip position="top" at={max} />
-          <LineChart.Dot color="red" at={min} />
           <LineChart.Tooltip position="bottom" at={min} yGutter={-10} />
         </LineChart.Path>
       )}

--- a/example/src/LineChart.tsx
+++ b/example/src/LineChart.tsx
@@ -60,6 +60,8 @@ export default function App() {
         )}
       </LineChart.Path>
         */}
+      <LineChart.Tooltip position="bottom" at={3} yGutter={-10} />
+      <LineChart.Tooltip position="top" at={data.length} />
       <LineChart.CursorCrosshair
         onActivated={invokeHaptic}
         onEnded={invokeHaptic}

--- a/example/src/LineChart.tsx
+++ b/example/src/LineChart.tsx
@@ -48,7 +48,10 @@ export default function App() {
 
   let chart = (
     <LineChart>
-      <LineChart.Path color="black" />
+      <LineChart.Path color="black">
+        <LineChart.Tooltip position="bottom" at={3} yGutter={-10} />
+        <LineChart.Tooltip position="top" at={data.length} />
+      </LineChart.Path>
       {/* <LineChart.Path color="black">
         <LineChart.Gradient color="black" />
         <LineChart.HorizontalLine at={{ index: 0 }} />
@@ -60,8 +63,6 @@ export default function App() {
         )}
       </LineChart.Path>
         */}
-      <LineChart.Tooltip position="bottom" at={3} yGutter={-10} />
-      <LineChart.Tooltip position="top" at={data.length} />
       <LineChart.CursorCrosshair
         onActivated={invokeHaptic}
         onEnded={invokeHaptic}

--- a/example/src/LineChart.tsx
+++ b/example/src/LineChart.tsx
@@ -10,6 +10,7 @@ import { Platform } from 'react-native';
 
 import mockData from './data/line-data.json';
 import mockData2 from './data/line-data2.json';
+import { useMemo } from 'react';
 
 function invokeHaptic() {
   if (['ios', 'android'].includes(Platform.OS)) {
@@ -44,14 +45,33 @@ export default function App() {
     });
   };
 
+  const [toggleMinMaxLabels, setToggleMinMaxLabels] = React.useState(false);
+
   let dataProp: TLineChartDataProp = data;
+  const [min, max] = useMemo(() => {
+    if (Array.isArray(dataProp)) {
+      const values = dataProp.map((d) => d.value);
+      const _min = Math.min(...values);
+      const _max = Math.max(...values);
+      return [
+        values.findIndex((v) => v === _min),
+        values.findIndex((v) => v === _max),
+      ];
+    }
+    return [0, 0];
+  }, [dataProp]);
 
   let chart = (
     <LineChart>
-      <LineChart.Path color="black">
-        <LineChart.Tooltip position="bottom" at={3} yGutter={-10} />
-        <LineChart.Tooltip position="top" at={data.length} />
-      </LineChart.Path>
+      {!toggleMinMaxLabels && <LineChart.Path color="black" />}
+      {toggleMinMaxLabels && (
+        <LineChart.Path color="black">
+          <LineChart.Dot color="green" at={max} />
+          <LineChart.Tooltip position="top" at={max} />
+          <LineChart.Dot color="red" at={min} />
+          <LineChart.Tooltip position="bottom" at={min} yGutter={-10} />
+        </LineChart.Path>
+      )}
       {/* <LineChart.Path color="black">
         <LineChart.Gradient color="black" />
         <LineChart.HorizontalLine at={{ index: 0 }} />
@@ -167,6 +187,7 @@ export default function App() {
             </Button>
             <Button onPress={toggleMultiData}>{`Multi Data`}</Button>
             <Button onPress={togglePartialDay}>{`Partial Day`}</Button>
+            <Button onPress={() => setToggleMinMaxLabels((p) => !p)}>{`Toggle min/max labels`}</Button>
           </Flex>
         </Box>
         {!multiData && (

--- a/src/charts/line/Chart.tsx
+++ b/src/charts/line/Chart.tsx
@@ -6,10 +6,13 @@ import { LineChartContext } from './Context';
 import { LineChartIdProvider, useLineChartData } from './Data';
 
 import { getArea, getPath } from './utils';
+import { parse, Path } from 'react-native-redash';
 
 export const LineChartDimensionsContext = React.createContext({
   width: 0,
   height: 0,
+  pointWidth: 0,
+  parsedPath: {} as Path,
   path: '',
   area: '',
   shape: d3Shape.curveBumpX,
@@ -85,9 +88,18 @@ export function LineChart({
     return '';
   }, [data, pathWidth, height, yGutter, shape, yDomain]);
 
+  const dataLength = data.length;
+  const parsedPath = React.useMemo(() => parse(path), [path]);
+  const pointWidth = React.useMemo(
+    () => width / (dataLength - 1),
+    [dataLength, width]
+  );
+
   const contextValue = React.useMemo(
     () => ({
       gutter: yGutter,
+      parsedPath,
+      pointWidth,
       area,
       path,
       width,
@@ -95,7 +107,17 @@ export function LineChart({
       pathWidth,
       shape,
     }),
-    [yGutter, area, path, width, height, pathWidth, shape]
+    [
+      yGutter,
+      parsedPath,
+      pointWidth,
+      area,
+      path,
+      width,
+      height,
+      pathWidth,
+      shape,
+    ]
   );
 
   return (

--- a/src/charts/line/ChartPath.tsx
+++ b/src/charts/line/ChartPath.tsx
@@ -18,6 +18,7 @@ const BACKGROUND_COMPONENTS = [
   'LineChartHorizontalLine',
   'LineChartGradient',
   'LineChartDot',
+  'LineChartTooltip',
 ];
 const FOREGROUND_COMPONENTS = ['LineChartHighlight', 'LineChartDot'];
 

--- a/src/charts/line/Cursor.tsx
+++ b/src/charts/line/Cursor.tsx
@@ -7,7 +7,6 @@ import {
   LongPressGestureHandlerProps,
 } from 'react-native-gesture-handler';
 import Animated, { useAnimatedGestureHandler } from 'react-native-reanimated';
-import { parse } from 'react-native-redash';
 
 import { LineChartDimensionsContext } from './Chart';
 import { useLineChart } from './useLineChart';
@@ -26,15 +25,10 @@ export function LineChartCursor({
   type,
   ...props
 }: LineChartCursorProps) {
-  const { pathWidth: width, path } = React.useContext(
+  const { pathWidth: width, parsedPath } = React.useContext(
     LineChartDimensionsContext
   );
   const { currentX, currentIndex, isActive, data } = useLineChart();
-
-  const parsedPath = React.useMemo(
-    () => (path ? parse(path) : undefined),
-    [path]
-  );
 
   const onGestureEvent = useAnimatedGestureHandler<
     GestureEvent<LongPressGestureHandlerEventPayload>

--- a/src/charts/line/Dot.tsx
+++ b/src/charts/line/Dot.tsx
@@ -8,7 +8,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { Circle, CircleProps } from 'react-native-svg';
-import { getYForX, parse } from 'react-native-redash';
+import { getYForX } from 'react-native-redash';
 
 import { LineChartDimensionsContext } from './Chart';
 import { LineChartPathContext } from './ChartPath';
@@ -57,8 +57,8 @@ export function LineChartDot({
   size = 4,
   outerSize = size * 4,
 }: LineChartDotProps) {
-  const { data, isActive } = useLineChart();
-  const { path, pathWidth: width } = React.useContext(
+  const { isActive } = useLineChart();
+  const { parsedPath, pointWidth } = React.useContext(
     LineChartDimensionsContext
   );
 
@@ -69,17 +69,6 @@ export function LineChartDot({
   const color = isInactive ? inactiveColor || defaultColor : defaultColor;
   const opacity = isInactive && !inactiveColor ? 0.5 : 1;
   const hasOuterDot = defaultHasOuterDot || hasPulse;
-
-  ////////////////////////////////////////////////////////////
-
-  const parsedPath = React.useMemo(() => parse(path), [path]);
-
-  ////////////////////////////////////////////////////////////
-
-  const pointWidth = React.useMemo(
-    () => width / (data.length - 1),
-    [data.length, width]
-  );
 
   ////////////////////////////////////////////////////////////
 

--- a/src/charts/line/HorizontalLine.tsx
+++ b/src/charts/line/HorizontalLine.tsx
@@ -5,7 +5,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { Line as SVGLine, LineProps } from 'react-native-svg';
-import { getYForX, parse } from 'react-native-redash';
+import { getYForX } from 'react-native-redash';
 
 import { LineChartDimensionsContext } from './Chart';
 import { useLineChart } from './useLineChart';
@@ -53,16 +53,10 @@ export function LineChartHorizontalLine({
   at = { index: 0 },
   offsetY = 0,
 }: HorizontalLineProps) {
-  const { width, path, height, gutter } = React.useContext(
+  const { width, parsedPath, pointWidth, height, gutter } = React.useContext(
     LineChartDimensionsContext
   );
-  const { data, yDomain } = useLineChart();
-
-  const parsedPath = React.useMemo(() => parse(path), [path]);
-  const pointWidth = React.useMemo(
-    () => width / data.length,
-    [data.length, width]
-  );
+  const { yDomain } = useLineChart();
 
   const y = useDerivedValue(() => {
     if (typeof at === 'number' || at.index != null) {

--- a/src/charts/line/HoverTrap/index.web.tsx
+++ b/src/charts/line/HoverTrap/index.web.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { parse } from 'react-native-redash';
 
 import { LineChartDimensionsContext } from '../Chart';
 import { useLineChart } from '../useLineChart';
@@ -50,13 +49,8 @@ function isHoverEnabled(): boolean {
 }
 
 export const LineChartHoverTrap = () => {
-  const { width, path } = React.useContext(LineChartDimensionsContext);
+  const { width, parsedPath } = React.useContext(LineChartDimensionsContext);
   const { currentX, currentIndex, isActive, data } = useLineChart();
-
-  const parsedPath = React.useMemo(
-    () => (path ? parse(path) : undefined),
-    [path]
-  );
 
   const onMouseMove = React.useCallback(
     ({ x }: { x: number }) => {

--- a/src/charts/line/PriceText.tsx
+++ b/src/charts/line/PriceText.tsx
@@ -11,6 +11,11 @@ export type LineChartPriceTextProps = {
   precision?: number;
   variant?: 'formatted' | 'value';
   style?: Animated.AnimateProps<RNTextProps>['style'];
+  /**
+   * By default, it will use the current active index from the chart.
+   * If this is set it will use the index provided.
+   */
+  index?: number;
 };
 
 LineChartPriceText.displayName = 'LineChartPriceText';
@@ -20,7 +25,8 @@ export function LineChartPriceText({
   precision = 2,
   variant = 'formatted',
   style,
+  index,
 }: LineChartPriceTextProps) {
-  const price = useLineChartPrice({ format, precision });
+  const price = useLineChartPrice({ format, precision, index });
   return <AnimatedText text={price[variant]} style={style} />;
 }

--- a/src/charts/line/Tooltip.tsx
+++ b/src/charts/line/Tooltip.tsx
@@ -66,7 +66,7 @@ export function LineChartTooltip({
   // TODO: put these two in context, as they are used in other parts like this as well
   const parsedPath = React.useMemo(() => parse(path), [path]);
   const pointWidth = React.useMemo(
-    () => width / dataLength,
+    () => width / (dataLength - 1),
     [dataLength, width]
   );
 

--- a/src/charts/line/Tooltip.tsx
+++ b/src/charts/line/Tooltip.tsx
@@ -4,6 +4,7 @@ import Animated, {
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
+  withTiming,
 } from 'react-native-reanimated';
 
 import { LineChartDimensionsContext } from './Chart';
@@ -121,6 +122,12 @@ export function LineChartTooltip({
       }
     }
 
+    let opacity = isActive.value ? 1 : 0;
+    if (isStatic) {
+      // Only show static when there is no active cursor
+      opacity = withTiming(isActive.value ? 0 : 1);
+    }
+
     return {
       transform: [
         { translateX: x - translateXOffset },
@@ -128,8 +135,7 @@ export function LineChartTooltip({
           translateY: translateY,
         },
       ],
-      // XOR, either its active or its static. When active fade out static ones
-      opacity: isActive.value !== isStatic ? 1 : 0,
+      opacity: opacity,
     };
   });
 

--- a/src/charts/line/Tooltip.tsx
+++ b/src/charts/line/Tooltip.tsx
@@ -63,7 +63,7 @@ export function LineChartTooltip({
     [elementHeight, elementWidth, x]
   );
 
-  // TODO: put these two in context, as they are used in other parts like this as well
+  // TODO: put these two in context, as they are used in other parts like this as well?
   const parsedPath = React.useMemo(() => parse(path), [path]);
   const pointWidth = React.useMemo(
     () => width / (dataLength - 1),
@@ -86,6 +86,7 @@ export function LineChartTooltip({
     // the tooltip is considered static when the user specified an `at` prop
     const isStatic = atYPosition.value != null;
 
+    // Calculate X position:
     const x = atXPosition ?? currentX.value;
     if (x < elementWidth.value / 2 + xGutter) {
       const xOffset = elementWidth.value / 2 + xGutter - x;
@@ -96,9 +97,9 @@ export function LineChartTooltip({
       translateXOffset = translateXOffset + xOffset;
     }
 
+    // Calculate Y position:
     let translateYOffset = 0;
     const y = atYPosition.value ?? currentY.value;
-
     if (position === 'top') {
       translateYOffset = elementHeight.value / 2 + cursorGutter;
       if (y - translateYOffset < yGutter) {
@@ -111,6 +112,7 @@ export function LineChartTooltip({
       }
     }
 
+    // determine final translateY value
     let translateY: number | undefined;
     if (type === 'crosshair' || isStatic) {
       translateY = y - translateYOffset;

--- a/src/charts/line/Tooltip.tsx
+++ b/src/charts/line/Tooltip.tsx
@@ -21,7 +21,13 @@ export type LineChartTooltipProps = Animated.AnimateProps<ViewProps> & {
   position?: 'top' | 'bottom';
   textProps?: LineChartPriceTextProps;
   textStyle?: LineChartPriceTextProps['style'];
-
+  /**
+   * When specified the tooltip is considered static, and will
+   * always be rendered at the given index, unless there is interaction
+   * with the chart (like interacting with a cursor).
+   *
+   * @default undefined
+   */
   at?: number;
 };
 
@@ -63,6 +69,7 @@ export function LineChartTooltip({
     [dataLength, width]
   );
 
+  // When the user set a `at` index, get the index's y & x positions
   const atXPosition = useMemo(
     () => (at == null ? undefined : pointWidth * at),
     [at, pointWidth]
@@ -75,6 +82,7 @@ export function LineChartTooltip({
 
   const animatedCursorStyle = useAnimatedStyle(() => {
     let translateXOffset = elementWidth.value / 2;
+    // the tooltip is considered static when the user specified an `at` prop
     const isStatic = atYPosition.value != null;
 
     const x = atXPosition ?? currentX.value;

--- a/src/charts/line/Tooltip.tsx
+++ b/src/charts/line/Tooltip.tsx
@@ -11,7 +11,7 @@ import { LineChartDimensionsContext } from './Chart';
 import { CursorContext } from './Cursor';
 import { LineChartPriceText, LineChartPriceTextProps } from './PriceText';
 import { useLineChart } from './useLineChart';
-import { getYForX, parse } from 'react-native-redash';
+import { getYForX } from 'react-native-redash';
 import { useMemo } from 'react';
 
 export type LineChartTooltipProps = Animated.AnimateProps<ViewProps> & {
@@ -45,10 +45,11 @@ export function LineChartTooltip({
   at,
   ...props
 }: LineChartTooltipProps) {
-  const { width, height, path } = React.useContext(LineChartDimensionsContext);
+  const { width, height, parsedPath, pointWidth } = React.useContext(
+    LineChartDimensionsContext
+  );
   const { type } = React.useContext(CursorContext);
-  const { currentX, currentY, isActive, data } = useLineChart();
-  const dataLength = data.length;
+  const { currentX, currentY, isActive } = useLineChart();
 
   const x = useSharedValue(0);
   const elementWidth = useSharedValue(0);
@@ -61,13 +62,6 @@ export function LineChartTooltip({
       elementHeight.value = event.nativeEvent.layout.height;
     },
     [elementHeight, elementWidth, x]
-  );
-
-  // TODO: put these two in context, as they are used in other parts like this as well?
-  const parsedPath = React.useMemo(() => parse(path), [path]);
-  const pointWidth = React.useMemo(
-    () => width / (dataLength - 1),
-    [dataLength, width]
   );
 
   // When the user set a `at` index, get the index's y & x positions

--- a/src/charts/line/usePrice.ts
+++ b/src/charts/line/usePrice.ts
@@ -7,14 +7,19 @@ import { useLineChart } from './useLineChart';
 export function useLineChartPrice({
   format,
   precision = 2,
-}: { format?: TFormatterFn<string>; precision?: number } = {}) {
+  index,
+}: { format?: TFormatterFn<string>; precision?: number; index?: number } = {}) {
   const { currentIndex, data } = useLineChart();
 
   const float = useDerivedValue(() => {
-    if (typeof currentIndex.value === 'undefined' || currentIndex.value === -1)
+    if (
+      (typeof currentIndex.value === 'undefined' ||
+        currentIndex.value === -1) &&
+      index == null
+    )
       return '';
     let price = 0;
-    price = data[currentIndex.value].value;
+    price = data[Math.min(index ?? currentIndex.value, data.length - 1)].value;
     return price.toFixed(precision).toString();
   });
   const formatted = useDerivedValue(() => {


### PR DESCRIPTION
### What

This PR adds support for labels / static tooltips.
Fix: #44

https://user-images.githubusercontent.com/16821682/157069765-6842361c-b5cf-4e56-8f33-93cb08ee245c.mp4

### The API

I used the same `at` prop as we're using for the `Dots`. By specifying this prop the Tooltip becomes "static"

I updated the documentation and the example app, so you can read and try it out.

I am more than open for a discussion about the API (or the code ofc), I kind of freestyled that.

### Dev notes:

- I moved the `parsedPath` and `pointWidth` to the line's context as I was noticing that when using many components (tooltips, horizontal lines, dots) there were _slight_ performance drops by 1-2 frames, because every component was calculating these on their own.
- I added the possibility to use the `usePrice` hook with a `index` so we can "query" data statically from the hook. I needed that so that the tooltips won't update all the time. Not sure if that decision is fine/good. 
- I didn't add transitions to the static tooltips when changing the graph data, yet. I think them just changing position is fine, and a transX/Y animation looked weird. Maybe we want some Fade In/Out effect (reference: coinbase app), however I'd prefer to do that in a separate PR to keep this one clean 
