### PR TITLE
feat. add snapToPoint for line chart and support for supplied xDomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,7 @@ To customize the formatting of the date/time text, you can supply a `format` fun
 | `crosshairWrapperProps` | `ViewProps`                    |           | Props of the wrapper component of the crosshair |
 | `crosshairProps`        | `ViewProps`                    |           | Props of the crosshair dot                      |
 | `crosshairOuterProps`   | `ViewProps`                    |           | Props of the crosshair outer dot                |
+| `snapToPoint`           | `boolean`                      | `false`   | Snap cursor to X position of nearest data point |
 | `...props`              | `LongPressGestureHandlerProps` |           |                                                 |
 
 ### LineChart.CursorLine

--- a/src/charts/line/Chart.tsx
+++ b/src/charts/line/Chart.tsx
@@ -47,7 +47,7 @@ export function LineChart({
   absolute,
   ...props
 }: LineChartProps) {
-  const { yDomain, xLength } = React.useContext(LineChartContext);
+  const { yDomain, xLength, xDomain } = React.useContext(LineChartContext);
   const { data } = useLineChartData({
     id,
   });
@@ -69,10 +69,11 @@ export function LineChart({
         gutter: yGutter,
         shape,
         yDomain,
+        xDomain,
       });
     }
     return '';
-  }, [data, pathWidth, height, yGutter, shape, yDomain]);
+  }, [data, pathWidth, height, yGutter, shape, yDomain, xDomain]);
 
   const area = React.useMemo(() => {
     if (data && data.length > 0) {

--- a/src/charts/line/Context.tsx
+++ b/src/charts/line/Context.tsx
@@ -19,6 +19,7 @@ export const LineChartContext = React.createContext<TLineChartContext>({
     min: 0,
     max: 0,
   },
+  xDomain: undefined,
   xLength: 0,
 });
 
@@ -28,6 +29,7 @@ type LineChartProviderProps = {
   yRange?: YRangeProp;
   onCurrentIndexChange?: (x: number) => void;
   xLength?: number;
+  xDomain?: [number, number];
 };
 
 LineChartProvider.displayName = 'LineChartProvider';
@@ -38,6 +40,7 @@ export function LineChartProvider({
   yRange,
   onCurrentIndexChange,
   xLength,
+  xDomain,
 }: LineChartProviderProps) {
   const currentX = useSharedValue(-1);
   const currentIndex = useSharedValue(-1);
@@ -60,6 +63,7 @@ export function LineChartProvider({
         min: yRange?.min ?? Math.min(...values),
         max: yRange?.max ?? Math.max(...values),
       },
+      xDomain,
       xLength:
         xLength ?? (Array.isArray(data) ? data : Object.values(data)[0]).length,
     };
@@ -72,6 +76,7 @@ export function LineChartProvider({
     yRange?.max,
     yRange?.min,
     xLength,
+    xDomain,
   ]);
 
   useAnimatedReaction(

--- a/src/charts/line/Cursor.tsx
+++ b/src/charts/line/Cursor.tsx
@@ -14,6 +14,7 @@ import { useLineChart } from './useLineChart';
 export type LineChartCursorProps = LongPressGestureHandlerProps & {
   children: React.ReactNode;
   type: 'line' | 'crosshair';
+  snapToPoint?: boolean;
 };
 
 export const CursorContext = React.createContext({ type: '' });
@@ -22,6 +23,7 @@ LineChartCursor.displayName = 'LineChartCursor';
 
 export function LineChartCursor({
   children,
+  snapToPoint,
   type,
   ...props
 }: LineChartCursorProps) {
@@ -37,7 +39,6 @@ export function LineChartCursor({
       if (parsedPath) {
         const boundedX = Math.max(0, x <= width ? x : width);
         isActive.value = true;
-        currentX.value = boundedX;
 
         // on Web, we could drag the cursor to be negative, breaking it
         // so we clamp the index at 0 to fix it
@@ -47,6 +48,24 @@ export function LineChartCursor({
           minIndex,
           Math.round(boundedX / width / (1 / (data.length - 1)))
         );
+
+        if (currentIndex.value !== boundedIndex && snapToPoint) {
+          const currentIndexCurve = parsedPath.curves[boundedIndex];
+
+          // We need to ensure we snap to the correct point on the path.
+          let resX
+          if (currentIndexCurve) {
+            const p0 = (boundedIndex > 0 ? parsedPath.curves[boundedIndex - 1].to : parsedPath.move).x
+            resX = p0
+          } else {
+            resX = parsedPath.curves[parsedPath.curves.length - 1].to.x
+          }
+
+          currentX.value = resX;
+
+        } else if (!snapToPoint) {
+          currentX.value = boundedX;
+        }
 
         currentIndex.value = boundedIndex;
       }

--- a/src/charts/line/types.ts
+++ b/src/charts/line/types.ts
@@ -18,6 +18,7 @@ export type TLineChartContext = {
   domain: TLineChartDomain;
   yDomain: YDomain;
   xLength: number;
+  xDomain?: [number, number] | undefined;
 };
 
 export type YRangeProp = {

--- a/src/charts/line/utils/getPath.ts
+++ b/src/charts/line/utils/getPath.ts
@@ -14,6 +14,7 @@ export function getPath({
   gutter,
   shape: _shape,
   yDomain,
+  xDomain,
 }: {
   data: TLineChartData;
   from?: number;
@@ -23,11 +24,12 @@ export function getPath({
   gutter: number;
   shape?: unknown;
   yDomain: YDomain;
+  xDomain?: [number, number];
 }): string {
-  const timestamps = data.map((_, i) => i);
+  const timestamps = data.map(({ timestamp }, i) => (xDomain ? timestamp : i));
 
   const scaleX = scaleLinear()
-    .domain([Math.min(...timestamps), Math.max(...timestamps)])
+    .domain(xDomain ?? [Math.min(...timestamps), Math.max(...timestamps)])
     .range([0, width]);
   const scaleY = scaleLinear()
     .domain([yDomain.min, yDomain.max])
@@ -41,7 +43,7 @@ export function getPath({
             .find((item) => item.timestamp === d.timestamp)
         : true
     )
-    .x((_: unknown, i: number) => scaleX(i))
+    .x((_: unknown, i: number) => scaleX(xDomain ? timestamps[i] : i))
     .y((d: { value: number }) => scaleY(d.value))
     .curve(_shape)(data);
   return path;


### PR DESCRIPTION
**Purpose**
Currently, the cursor moves smoothly along the line which creates a nice user experience but it may not accurately represent the data underneath the cursor at the point in time along x-axis. 

By adding this `snapToPoint` functionality, we are now able to ensure the cursor sticks to the nearest data point on the chart compared to where the cursor/touch-point is. This can be important in finance applications where you don't want to falsely represent a value at a particular point in time.

**xDomain purpose**
When showing a chart that has partial data for the day (but is still represented on the x-axis with the full scale), we need to ensure the linear scale is performing correctly. 


# Snap On
e.g.
```
 <LineChart.CursorCrosshair
  snapToPoint // This is the important prop
  color={'transparent'}
  minDurationMs={150}
  onEnded={onTouchEnd}
  onActivated={onTouchActivated}
/>
```

https://user-images.githubusercontent.com/6579750/213583260-8414bd8d-4c6b-41ba-8cd6-681f50a98f5f.mov

# Snap off - Default behaviour
https://user-images.githubusercontent.com/6579750/213583275-df8c6ab5-f936-4e34-940d-d6bd30cec435.mov

