### PR TITLE
Fix highlight path

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ To achieve this, simply add `<LineChart.HoverTrap />` as the child of your curso
 <LineChart.Provider data={data}>
   <LineChart>
     <LineChart.Path color="hotpink" />
-    <LineChart.CursorCrosshair color="hotpink" >
+    <LineChart.CursorCrosshair color="hotpink">
       <LineChart.HoverTrap />
     </LineChart.CursorCrosshair>
   </LineChart>

--- a/example/README.md
+++ b/example/README.md
@@ -2,23 +2,31 @@
 
 ## Getting Started
 
-First install project dependencies in this directory:
+First install project dependencies in this directory (`yarn` is recommended):
 
-`npm install`
+```bash
+yarn install
+```
 
 After dependencies are installed, you can go ahead and run the project on either a simulator, or a real device using the following commands
 
 For iOS:
 
-`npm run ios`
+```bash
+yarn run ios
+```
 
 For Android:
 
-`npm run android`
+```bash
+yarn run android
+```
 
 For Web:
 
-`npm run web`
+```bash
+yarn run web
+```
 
 
 ## Example Charts
@@ -29,4 +37,5 @@ The following charts are included:
 - Line Chart
 
 ### Sample Data
+
 The charts in this example use hardcoded data, which is stored in the `src/data` directory

--- a/example/src/LineChart.tsx
+++ b/example/src/LineChart.tsx
@@ -51,6 +51,7 @@ export default function App() {
 
   const [toggleMinMaxLabels, setToggleMinMaxLabels] = React.useState(false);
   const [toggleSnapToPoint, setToggleSnapToPoint] = React.useState(false);
+  const [toggleHighlight, setToggleHighlight] = React.useState(false);
 
   let dataProp: TLineChartDataProp = data;
   const [min, max] = useMemo(() => {
@@ -68,25 +69,22 @@ export default function App() {
 
   let chart = (
     <LineChart>
-      {!toggleMinMaxLabels && <LineChart.Path color="black" />}
-      {toggleMinMaxLabels && (
-        <LineChart.Path color="black">
-          <LineChart.Gradient color="black" />
-          <LineChart.Tooltip position="top" at={max} />
-          <LineChart.Tooltip position="bottom" at={min} yGutter={-10} />
-        </LineChart.Path>
-      )}
-      {/* <LineChart.Path color="black">
-        <LineChart.Gradient color="black" />
-        <LineChart.HorizontalLine at={{ index: 0 }} />
-        <LineChart.Highlight color="red" from={10} to={15} />
-        <LineChart.Dot color="red" at={10} />
-        <LineChart.Dot color="red" at={15} />
-        {partialDay && (
-          <LineChart.Dot at={data.length - 1} color="red" hasPulse />
+      <LineChart.Path color="black">
+        {toggleMinMaxLabels && (
+          <>
+            <LineChart.Gradient color="black" />
+            <LineChart.Tooltip position="top" at={max} />
+            <LineChart.Tooltip position="bottom" at={min} yGutter={-10} />
+          </>
+        )}
+        {toggleHighlight && (
+          <LineChart.Highlight
+            color="red"
+            from={Math.floor(data.length / 3)}
+            to={Math.floor(data.length * (2/3))}
+          />
         )}
       </LineChart.Path>
-        */}
       <LineChart.CursorCrosshair
         snapToPoint={toggleSnapToPoint}
         onActivated={invokeHaptic}
@@ -200,6 +198,9 @@ export default function App() {
             </Button>
             <Button onPress={toggleMultiData}>{`Multi Data`}</Button>
             <Button onPress={togglePartialDay}>{`Partial Day`}</Button>
+            <Button onPress={() => setToggleHighlight((val) => !val)}>
+              Toggle highlight
+            </Button>
             <Button
               onPress={() => setToggleMinMaxLabels((p) => !p)}
             >{`Toggle min/max labels`}</Button>


### PR DESCRIPTION
Use clipping path to fix issue https://github.com/coinjar/react-native-wagmi-charts/issues/85 where highlight path does not take into account the rest of the path.

|Before|After|
|---|---|
|<img width="356" alt="before" src="https://github.com/coinjar/react-native-wagmi-charts/assets/27768821/cea8eca1-1321-4664-894e-986059f447ec">|<img width="356" alt="after" src="https://github.com/coinjar/react-native-wagmi-charts/assets/27768821/1c5fdce2-191a-470e-8e35-98eacdb5c7d5">|
