### PR TITLE
fix: split SVGs in ChartPath to improve performance

### DIFF
--- a/src/charts/line/ChartPath.tsx
+++ b/src/charts/line/ChartPath.tsx
@@ -152,6 +152,8 @@ export function LineChartPathWrapper({
               width={strokeWidth}
               {...pathProps}
             />
+          </Svg>
+          <Svg style={StyleSheet.absoluteFill}>
             {backgroundChildren}
           </Svg>
         </View>
@@ -166,6 +168,8 @@ export function LineChartPathWrapper({
         <View style={StyleSheet.absoluteFill}>
           <AnimatedSVG animatedProps={svgProps} height={height}>
             <LineChartPath color={color} width={strokeWidth} {...pathProps} />
+          </AnimatedSVG>
+          <AnimatedSVG animatedProps={svgProps} height={height} style={StyleSheet.absoluteFill}>
             {foregroundChildren}
           </AnimatedSVG>
         </View>


### PR DESCRIPTION
## Description

This improves the UI's FPS when there's 200+ data points in a graph.

Thanks to @wojtus7 for implementing this patch.

## Screen Captures

Here's a before + after video. You can see how the UI's FPS increase when applying this fix.

<video src="https://github.com/coinjar/react-native-wagmi-charts/assets/626213/95a3d728-c930-4b1b-b039-47c0494851c4"/>




