### PR TITLE
Import React

### DIFF
--- a/src/charts/candle/DatetimeText.tsx
+++ b/src/charts/candle/DatetimeText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 

--- a/src/charts/candle/DatetimeText.tsx
+++ b/src/charts/candle/DatetimeText.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 

--- a/src/charts/candle/Line.tsx
+++ b/src/charts/candle/Line.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { StyleSheet } from 'react-native';
 import Svg, { Line as SVGLine, LineProps } from 'react-native-svg';
 

--- a/src/charts/candle/PriceText.tsx
+++ b/src/charts/candle/PriceText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 

--- a/src/charts/candle/PriceText.tsx
+++ b/src/charts/candle/PriceText.tsx
@@ -1,7 +1,8 @@
+import * as React from 'react';
 import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
-import type { TFormatterFn, TPriceType } from './types';
 
+import type { TFormatterFn, TPriceType } from './types';
 import { useCandlestickChartPrice } from './usePrice';
 import { AnimatedText } from '../../components/AnimatedText';
 

--- a/src/charts/line/Data.tsx
+++ b/src/charts/line/Data.tsx
@@ -1,7 +1,7 @@
-import type { TLineChartData } from './types';
-import { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 import type { ReactNode } from 'react';
-import type { TLineChartDataProp } from './types';
+
+import type { TLineChartData, TLineChartDataProp } from './types';
 
 export const DefaultLineChartId = '__LineChartData';
 
@@ -76,9 +76,8 @@ function validateLineChartId(dataContext: LineChartDataContext, id?: string) {
     const joinedIds = otherIds.join(', ');
 
     const suggestion = otherIds.length
-      ? `Did you mean to use ${
-          singular ? 'this ID' : 'one of these IDs'
-        }: ${joinedIds}`
+      ? `Did you mean to use ${singular ? 'this ID' : 'one of these IDs'
+      }: ${joinedIds}`
       : `You didn't pass any IDs to your <LineChart.Provider />'s data prop. Did you mean to pass an array instead?`;
 
     console.warn(
@@ -92,9 +91,8 @@ ${suggestion}`
 
     const joinedIds = otherIds.join(', ');
     const suggestion = otherIds.length
-      ? `Did you mean to use ${
-          singular ? 'this ID' : 'one of these IDs'
-        }: ${joinedIds}`
+      ? `Did you mean to use ${singular ? 'this ID' : 'one of these IDs'
+      }: ${joinedIds}`
       : `You didn't pass any IDs to your <LineChart.Provider />'s data prop. Did you mean to pass an array instead?`;
 
     console.error(`[react-native-wagmi-charts] Missing data "id" prop on LineChart. You must pass an id prop to <LineChart /> when using a dictionary for your data.

--- a/src/charts/line/DatetimeText.tsx
+++ b/src/charts/line/DatetimeText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 

--- a/src/charts/line/DatetimeText.tsx
+++ b/src/charts/line/DatetimeText.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 

--- a/src/charts/line/Group.tsx
+++ b/src/charts/line/Group.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, Children, cloneElement } from 'react';
+import React, { ReactNode, Children, cloneElement } from 'react';
 import { ViewProps, View } from 'react-native';
 import flattenChildren from 'react-keyed-flatten-children';
 

--- a/src/charts/line/HoverTrap/index.tsx
+++ b/src/charts/line/HoverTrap/index.tsx
@@ -1,1 +1,3 @@
+import React from 'react';
+
 export const LineChartHoverTrap = () => <></>;

--- a/src/charts/line/PriceText.tsx
+++ b/src/charts/line/PriceText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 

--- a/src/charts/line/PriceText.tsx
+++ b/src/charts/line/PriceText.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { TextProps as RNTextProps } from 'react-native';
 import type Animated from 'react-native-reanimated';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,18 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "react-native-wagmi-charts": ["./src/index"],
+      "react-native-wagmi-charts": [
+        "./src/index"
+      ],
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
-    "lib": ["esnext"],
+    "jsx": "react",
+    "lib": [
+      "esnext"
+    ],
     "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Removing the `React` imports causes files to throw a `React is not defined` error (reported in https://github.com/coinjar/react-native-wagmi-charts/issues/179). This PR reverts the removal of these imports and updates the TypeScript rules to account for this.