### PR TITLE
make candle accessible in renderRect and renderLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,8 +974,8 @@ Place it as the child of your cursor component to trap hover events on Web. If y
 | `negativeColor` | `string`                                                                                                       | `#ef4444` | Color of the negative candles                                      |
 | `rectProps`     | `RectProps`                                                                                                    |           | Props of the SVG Rectangle. Takes React Native's SVG `Rect` props. |
 | `lineProps`     | `LineProps`                                                                                                    |           | Props of the SVG Line. Takes React Native's SVG `Line` props.      |
-| `renderRect`    | `({ x: number, y: number, width: number, height: number, fill: string }) => React.ReactNode`                   |           | Renders a custom rect component                                    |
-| `renderLine`    | `({ x1: number, x2: number, y1: number, y2: number, stroke: string, strokeWidth: number }) => React.ReactNode` |           | Renders a custom line component                                    |
+| `renderRect`    | `({ x: number, y: number, width: number, height: number, fill: string, candle: TCandle }) => React.ReactNode`                   |           | Renders a custom rect component                                    |
+| `renderLine`    | `({ x1: number, x2: number, y1: number, y2: number, stroke: string, strokeWidth: number, candle: TCandle }) => React.ReactNode` |           | Renders a custom line component                                    |
 | `...props`      | `SvgProps`                                                                                                     |           | This component also inherits React Native SVG's `Svg` props.       |
 
 ### CandlestickChart.Crosshair

--- a/src/charts/candle/Candle.tsx
+++ b/src/charts/candle/Candle.tsx
@@ -30,6 +30,7 @@ export type CandlestickChartCandleProps = {
     width,
     height,
     fill,
+    candle
   }: {
     x: NumberProp;
     y: NumberProp;
@@ -37,6 +38,7 @@ export type CandlestickChartCandleProps = {
     height: NumberProp;
     fill: ColorValue;
     useAnimations: boolean;
+    candle: TCandle;
   }) => React.ReactNode;
   renderLine?: ({
     x1,
@@ -45,6 +47,7 @@ export type CandlestickChartCandleProps = {
     y2,
     stroke,
     strokeWidth,
+    candle,
   }: {
     x1: NumberProp;
     y1: NumberProp;
@@ -53,6 +56,7 @@ export type CandlestickChartCandleProps = {
     stroke: ColorValue;
     strokeWidth: NumberProp;
     useAnimations: boolean;
+    candle: TCandle;
   }) => React.ReactNode;
 };
 
@@ -89,6 +93,7 @@ export const CandlestickChartCandle = ({
       y1: getY({ maxHeight, value: low, domain }),
       x2: x + width / 2,
       y2: getY({ maxHeight, value: high, domain }),
+      candle: candle,
       ...overrideLineProps,
     }),
     [
@@ -101,6 +106,7 @@ export const CandlestickChartCandle = ({
       overrideLineProps,
       width,
       x,
+      candle,
     ]
   );
   const animatedLineProps = useAnimatedProps(() => ({
@@ -118,6 +124,7 @@ export const CandlestickChartCandle = ({
       x: x + margin,
       y: getY({ maxHeight, value: max, domain }),
       height: getHeight({ maxHeight, value: max - min, domain }),
+      candle: candle,
       ...overrideRectProps,
     }),
     [
@@ -131,6 +138,7 @@ export const CandlestickChartCandle = ({
       overrideRectProps,
       width,
       x,
+      candle,
     ]
   );
   const animatedRectProps = useAnimatedProps(() => ({


### PR DESCRIPTION
see #192

This makes it possible to access the candle data from within the `renderRect` and `renderLine` functions.
This is usefull for me to be able to draw different candles or markers depending on the data.