### PR TITLE
Improving line chart tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,14 +914,15 @@ To customize the formatting of the date/time text, you can supply a `format` fun
 
 ### LineChart.Tooltip
 
-| Prop           | Type                  | Default | Description                                                                                                                    |
-| -------------- | --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `xGutter`      | `number`              | `8`     | X axis gutter in which the tooltip will not pass.                                                                              |
-| `yGutter`      | `number`              | `8`     | Y axis gutter in which the tooltip will not pass.                                                                              |
-| `cursorGutter` | `number`              | `48`    | Gutter (spacing) between the cursor and the tooltip.                                                                           |
-| `position`     | `"top"` or `"bottom"` | `"top"` | Position of the tooltip relative to the cursor.                                                                                |
-| `textStyle`    | `{}`                  |         | Style of the tooltip text                                                                                                      |
-| `at`           | `number`              |         | Make the tooltip static at the given `data` index (which shows the tooltip always, unless there is interaction with the chart) |
+| Prop                     | Type                                           | Default | Description                                                                                                                    |
+| ------------------------ | ---------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `xGutter`                | `number`                                       | `8`     | X axis gutter in which the tooltip will not pass.                                                                              |
+| `yGutter`                | `number`                                       | `8`     | Y axis gutter in which the tooltip will not pass.                                                                              |
+| `cursorGutter`           | `number`                                       | `48`    | Gutter (spacing) between the cursor and the tooltip.                                                                           |
+| `position`               | `"top"` or `"bottom"` or `"left"` or `"right"` | `"top"` | Position of the tooltip relative to the cursor.                                                                                |
+| `withHorizontalFloating` | `boolean`                                      | `false` | If set to `true`, the position will changes between `left` and `right` on if tooltip reaches the X axis gutters.               |
+| `textStyle`              | `{}`                                           |         | Style of the tooltip text                                                                                                      |
+| `at`                     | `number`                                       |         | Make the tooltip static at the given `data` index (which shows the tooltip always, unless there is interaction with the chart) |
 
 ### LineChart.PriceText
 
@@ -1033,12 +1034,12 @@ const { currentX, currentY, currentIndex, data, domain, isActive } =
 
 | Variable       | Type                                          | Default | Description                     |
 | -------------- | --------------------------------------------- | ------- | ------------------------------- |
-| `currentX`     | `SharedValue<number>`                |         | Current x position              |
-| `currentY`     | `SharedValue<number>`                |         | Current y position              |
-| `currentIndex` | `SharedValue<number>`                |         | Current index of the data       |
+| `currentX`     | `SharedValue<number>`                         |         | Current x position              |
+| `currentY`     | `SharedValue<number>`                         |         | Current y position              |
+| `currentIndex` | `SharedValue<number>`                         |         | Current index of the data       |
 | `data`         | `Array<{ timestamp: number, value: number }>` |         | Data of the chart               |
 | `domain`       | `[number, number]`                            |         | Y domain of the chart           |
-| `isActive`     | `SharedValue<boolean>`               |         | Is the chart active by gesture? |
+| `isActive`     | `SharedValue<boolean>`                        |         | Is the chart active by gesture? |
 
 ### LineChart.useDatetime
 
@@ -1103,8 +1104,8 @@ const { currentX, currentY, data, domain, step } = CandlestickChart.useChart();
 
 | Variable   | Type                                                                                   | Default | Description               |
 | ---------- | -------------------------------------------------------------------------------------- | ------- | ------------------------- |
-| `currentX` | `SharedValue<number>`                                                         |         | Current x position        |
-| `currentY` | `SharedValue<number>`                                                         |         | Current y position        |
+| `currentX` | `SharedValue<number>`                                                                  |         | Current x position        |
+| `currentY` | `SharedValue<number>`                                                                  |         | Current y position        |
 | `data`     | `Array<{ timestamp: number, open: number, high: number, low: number, close: number }>` |         | Data of the chart         |
 | `domain`   | `[number, number]`                                                                     |         | Y domain of the chart     |
 | `step`     | `number`                                                                               |         | Current index of the data |

--- a/example/src/LineChart.tsx
+++ b/example/src/LineChart.tsx
@@ -1,9 +1,18 @@
 import * as React from 'react';
 import * as haptics from 'expo-haptics';
 
-import { Box, Button, Flex, Heading, Stack, Text } from 'bumbag-native';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  RadioGroup,
+  Stack,
+  Text,
+} from 'bumbag-native';
 import {
   LineChart,
+  LineChartTooltipPosition,
   TLineChartDataProp,
   TLineChartPoint,
 } from 'react-native-wagmi-charts';
@@ -54,6 +63,10 @@ export default function App() {
   const [toggleSnapToPoint, setToggleSnapToPoint] = React.useState(false);
   const [toggleHighlight, setToggleHighlight] = React.useState(false);
 
+  const [floatingTooltip, setFloatingTooltip] = React.useState(false);
+  const [tooltipPosition, setTooltipPosition] =
+    React.useState<LineChartTooltipPosition>('top');
+
   let dataProp: TLineChartDataProp = data;
   const [min, max] = useMemo(() => {
     if (Array.isArray(dataProp)) {
@@ -92,7 +105,10 @@ export default function App() {
         onEnded={invokeHaptic}
         at={at}
       >
-        <LineChart.Tooltip position="top" />
+        <LineChart.Tooltip
+          position={tooltipPosition}
+          withHorizontalFloating={floatingTooltip}
+        />
         <LineChart.HoverTrap />
       </LineChart.CursorCrosshair>
     </LineChart>
@@ -112,7 +128,10 @@ export default function App() {
             onActivated={invokeHaptic}
             onEnded={invokeHaptic}
           >
-            <LineChart.Tooltip />
+            <LineChart.Tooltip
+              position={tooltipPosition}
+              withHorizontalFloating={floatingTooltip}
+            />
           </LineChart.CursorCrosshair>
         </LineChart>
         <LineChart id="two">
@@ -126,7 +145,10 @@ export default function App() {
             onActivated={invokeHaptic}
             onEnded={invokeHaptic}
           >
-            <LineChart.Tooltip />
+            <LineChart.Tooltip
+              position={tooltipPosition}
+              withHorizontalFloating={floatingTooltip}
+            />
           </LineChart.CursorCrosshair>
         </LineChart>
       </LineChart.Group>
@@ -160,7 +182,7 @@ export default function App() {
         {chart}
         <Box marginX="major-2" marginTop="major-2">
           <Heading.H6 marginBottom="major-2">Load Data</Heading.H6>
-          <Flex flexWrap="wrap">
+          <Flex flexWrap="wrap" marginBottom="major-2">
             <Button onPress={() => setData(mockData)}>Data 1</Button>
             <Button onPress={() => setData(mockData2)}>Data 2</Button>
             <Button onPress={() => setData(mockDataNonLinear)}>Data 3</Button>
@@ -217,8 +239,33 @@ export default function App() {
             <Button onPress={() => setToggleSnapToPoint((val) => !val)}>
               Toggle Snap {toggleSnapToPoint ? 'Off' : 'On'}
             </Button>
-            <Button onPress={() => setAt(Math.floor(Math.random() * data.length))}>Set Cursor</Button>
+            <Button
+              onPress={() => setAt(Math.floor(Math.random() * data.length))}
+            >
+              Set Cursor
+            </Button>
           </Flex>
+
+          <Text marginBottom="major-2">Tooltip position:</Text>
+          <RadioGroup
+            orientation="horizontal"
+            onChange={(value) =>
+              setTooltipPosition(value as LineChartTooltipPosition)
+            }
+            value={tooltipPosition}
+            options={[
+              { label: 'Top', value: 'top' },
+              { label: 'Bottom', value: 'bottom' },
+              { label: 'Left', value: 'left' },
+              { label: 'Right', value: 'right' },
+            ]}
+          />
+
+          {['left', 'right'].includes(tooltipPosition) && (
+            <Button onPress={() => setFloatingTooltip((val) => !val)}>
+              Toggle floating tooltip {floatingTooltip ? 'Off' : 'On'}
+            </Button>
+          )}
         </Box>
         {!multiData && (
           <Stack padding="major-2" spacing="major-1">


### PR DESCRIPTION
This PR introduces `left` and `right` positions for `LineChart.Tooltip`.

Additionally, it adds a new prop, `withHorizontalFloating`, enabling the tooltip to switch between left and right positions when it reaches the X-axis margins.

Here is the example app:

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-27 at 15 16 11](https://github.com/user-attachments/assets/3e7c44cc-669f-451f-bea4-481fab58a087)
