### PR TITLE
Update type definition jsdocs with the correct default values for Crosshair component

### DIFF
--- a/src/charts/candle/Crosshair.tsx
+++ b/src/charts/candle/Crosshair.tsx
@@ -25,11 +25,17 @@ type MaxDistOverride = LongPressGestureHandlerProps['maxDist'];
 
 type LongPressGestureHandlerOverride = Omit<LongPressGestureHandler, 'minDuration' | 'maxDist'> & {
   /**
-   * Minimum time, expressed in milliseconds, that a finger must remain pressed on the corresponding view. The default value is 0.
+   * Minimum time, expressed in milliseconds, that a finger must remain
+   * pressed on the corresponding view.
+   * @default 0
    */
   minDuration?: MinDurationOverride;
   /**
-   * Maximum distance, expressed in points, that defines how far the finger is allowed to travel during a long press gesture. If the finger travels further than the defined distance and the handler hasn't yet activated, it will fail to recognize the gesture. The default value is 999999.
+   * Maximum distance, expressed in points, that defines how far the finger is
+   * allowed to travel during a long press gesture. If the finger travels
+   * further than the defined distance and the handler hasn't yet activated, 
+   * it will fail to recognize the gesture. 
+   * @default 999999
    */
   maxDist?: MaxDistOverride;
 };

--- a/src/charts/candle/Crosshair.tsx
+++ b/src/charts/candle/Crosshair.tsx
@@ -20,7 +20,21 @@ import { CandlestickChartLine, CandlestickChartLineProps } from './Line';
 import { useCandlestickChart } from './useCandlestickChart';
 import { CandlestickChartCrosshairTooltipContext } from './CrosshairTooltip';
 
-type CandlestickChartCrosshairProps = LongPressGestureHandlerProps & {
+type MinDurationOverride = LongPressGestureHandlerProps['minDurationMs'];
+type MaxDistOverride = LongPressGestureHandlerProps['maxDist'];
+
+type LongPressGestureHandlerOverride = Omit<LongPressGestureHandler, 'minDuration' | 'maxDist'> & {
+  /**
+   * Minimum time, expressed in milliseconds, that a finger must remain pressed on the corresponding view. The default value is 0.
+   */
+  minDuration?: MinDurationOverride;
+  /**
+   * Maximum distance, expressed in points, that defines how far the finger is allowed to travel during a long press gesture. If the finger travels further than the defined distance and the handler hasn't yet activated, it will fail to recognize the gesture. The default value is 999999.
+   */
+  maxDist?: MaxDistOverride;
+};
+
+type CandlestickChartCrosshairProps = LongPressGestureHandlerOverride & {
   color?: string;
   children?: React.ReactNode;
   onCurrentXChange?: (value: number) => unknown;


### PR DESCRIPTION
Both `minDuration` and `maxDist` have incorrect default values described in the jsdocs (see attached images), as it is inherited from react-native-gesture-handler. This overrides them to label the type with the correct values

<img width="1018" alt="Screenshot 2025-03-06 at 22 14 52" src="https://github.com/user-attachments/assets/4b885553-5770-48cf-b161-9a01e045b49c" />
<img width="837" alt="Screenshot 2025-03-06 at 22 14 49" src="https://github.com/user-attachments/assets/19002521-e5cc-4cc0-8977-308abc4943ac" />

