### PR TITLE
Fixes reanimated warning message triggered by `<AnimatedText />`

### DIFF
--- a/src/components/AnimatedText.tsx
+++ b/src/components/AnimatedText.tsx
@@ -51,7 +51,6 @@ export const AnimatedText = ({ text, style }: AnimatedTextProps) => {
       underlineColorAndroid="transparent"
       editable={false}
       ref={Platform.select({ web: inputRef })}
-      value={text.value}
       style={[styles.text, style]}
       animatedProps={animatedProps}
     />


### PR DESCRIPTION
Fixes reanimated warning messages issue reported in https://github.com/coinjar/react-native-wagmi-charts/issues/189.

When using `"react-native-reanimated": "~3.16.1"`, this warning

```text
 WARN  [Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property or use `get` method of a shared value while React is rendering a component.

If you don't want to see this message, you can disable the `strict` mode. Refer to:
https://docs.swmansion.com/react-native-reanimated/docs/debugging/logger-configuration for more details.
```

appears during any interaction which renders `<AnimatedText />` (e.g. `<LineChart.DatetimeText />`).  Since the text itself is already covered by `useAnimatedProps`, the regular `value` prop can be removed keeping the same functionality without the warnings.