### PR TITLE
Fix line chart cursor crosshair animation

### DIFF
--- a/src/charts/line/CursorCrosshair.tsx
+++ b/src/charts/line/CursorCrosshair.tsx
@@ -55,6 +55,8 @@ export function LineChartCursorCrosshair({
           scale: enableSpringAnimation
             ? withSpring(isActive.value ? 1 : 0, {
                 damping: 10,
+                stiffness: 100,
+                mass: 0.3,
               })
             : 0,
         },


### PR DESCRIPTION
Reanimated 4 changes the default behavior of `withSpring`
https://docs.swmansion.com/react-native-reanimated/docs/guides/migration-from-3.x/#changed-the-default-behavior-of-withspring

This PR updates the line chart cursor crosshair animation to prevent it from bouncing repeatedly 

Current behavior without the fix:

https://github.com/user-attachments/assets/2a06b24d-905c-4980-b852-5a0d24e6ad87

