### PR TITLE
fix: replace deprecated Extrapolate with Extrapolation

### DIFF
--- a/src/charts/candle/utils/getHeight.ts
+++ b/src/charts/candle/utils/getHeight.ts
@@ -1,4 +1,4 @@
-import { interpolate, Extrapolate } from 'react-native-reanimated';
+import { interpolate, Extrapolation } from 'react-native-reanimated';
 
 import type { TDomain } from '../types';
 
@@ -16,6 +16,6 @@ export function getHeight({
     value,
     [0, Math.max(...domain) - Math.min(...domain)],
     [0, maxHeight],
-    Extrapolate.CLAMP
+    Extrapolation.CLAMP
   );
 }

--- a/src/charts/candle/utils/getPrice.ts
+++ b/src/charts/candle/utils/getPrice.ts
@@ -1,4 +1,4 @@
-import { interpolate, Extrapolate } from 'react-native-reanimated';
+import { interpolate, Extrapolation } from 'react-native-reanimated';
 
 import type { TDomain } from '../types';
 
@@ -13,5 +13,5 @@ export function getPrice({
 }) {
   'worklet';
   if (y === -1) return -1;
-  return interpolate(y, [0, maxHeight], domain.reverse(), Extrapolate.CLAMP);
+  return interpolate(y, [0, maxHeight], domain.reverse(), Extrapolation.CLAMP);
 }

--- a/src/charts/candle/utils/getY.ts
+++ b/src/charts/candle/utils/getY.ts
@@ -1,4 +1,4 @@
-import { interpolate, Extrapolate } from 'react-native-reanimated';
+import { interpolate, Extrapolation } from 'react-native-reanimated';
 
 import type { TDomain } from '../types';
 
@@ -12,5 +12,5 @@ export function getY({
   maxHeight: number;
 }) {
   'worklet';
-  return interpolate(value, domain, [maxHeight, 0], Extrapolate.CLAMP);
+  return interpolate(value, domain, [maxHeight, 0], Extrapolation.CLAMP);
 }


### PR DESCRIPTION
## Description

This PR fixes deprecated `Extrapolate` usage by replacing it with `Extrapolation` in react-native-reanimated.

## Changes

- Updated `src/charts/candle/utils/getHeight.ts`
- Updated `src/charts/candle/utils/getY.ts`
- Updated `src/charts/candle/utils/getPrice.ts`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code quality improvement

## Testing

- [x] No functional changes, only import updates
- [x] TypeScript warnings should be resolved

## Related Issues

Fixes deprecation warnings for `Extrapolate` usage.
