### PR TITLE
fix: candlestick tooltip z-index

### DIFF
--- a/src/charts/candle/Crosshair.tsx
+++ b/src/charts/candle/Crosshair.tsx
@@ -121,6 +121,12 @@ export function CandlestickChartCrosshair({
     <GestureDetector gesture={longPressGesture}>
       <Animated.View style={StyleSheet.absoluteFill}>
         <Animated.View
+          style={[StyleSheet.absoluteFill, vertical]}
+          {...verticalCrosshairProps}
+        >
+          <CandlestickChartLine color={color} x={0} y={height} {...lineProps} />
+        </Animated.View>
+        <Animated.View
           style={[StyleSheet.absoluteFill, horizontal]}
           {...horizontalCrosshairProps}
         >
@@ -130,12 +136,6 @@ export function CandlestickChartCrosshair({
           >
             {children}
           </CandlestickChartCrosshairTooltipContext.Provider>
-        </Animated.View>
-        <Animated.View
-          style={[StyleSheet.absoluteFill, vertical]}
-          {...verticalCrosshairProps}
-        >
-          <CandlestickChartLine color={color} x={0} y={height} {...lineProps} />
         </Animated.View>
       </Animated.View>
     </GestureDetector>


### PR DESCRIPTION
Move vertical crosshair line before crosshair children so that it renders behind the tooltip, not in front.

Before / After
<img width="700" height="310" alt="wagmi-candlestick-tooltip-bug" src="https://github.com/user-attachments/assets/e2ca39b3-eaef-406b-be68-1d83c48a9262" />

