### PR TITLE
feat: add persistOnEnd prop to keep cursor pinned after gesture ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,6 +871,7 @@ To customize the formatting of the date/time text, you can supply a `format` fun
 | `crosshairProps`        | `ViewProps`                    |           | Props of the crosshair dot                                            |
 | `crosshairOuterProps`   | `ViewProps`                    |           | Props of the crosshair outer dot                                      |
 | `snapToPoint`           | `boolean`                      | `false`   | **REACT NATIVE ONLY** Snap cursor to X position of nearest data point |
+| `persistOnEnd`             | `boolean`                      | `false`   | Keep the cursor pinned at its last position after the gesture ends    |
 | `at`                    | `number`                       |           | Index of followed `data` item.                                        |
 | `...props`              | `LongPressGestureHandlerProps` |           |                                                                       |
 
@@ -880,6 +881,7 @@ To customize the formatting of the date/time text, you can supply a `format` fun
 | ----------- | ----------- | -------- | ---------------------------------------------------------------- |
 | `color`     | `string`    | `"gray"` | Color of the cursor line                                         |
 | `lineProps` | `LineProps` |          | Props of the cursor line. Takes React Native SVG's `Line` props. |
+| `persistOnEnd` | `boolean`   | `false`  | Keep the cursor pinned at its last position after the gesture ends |
 | `at`        | `number`    |          | Index of followed `data` item.                                   |
 
 ### LineChart.Dot

--- a/example/src/LineChart.tsx
+++ b/example/src/LineChart.tsx
@@ -59,6 +59,7 @@ export default function App() {
 
   const [toggleMinMaxLabels, setToggleMinMaxLabels] = React.useState(false);
   const [toggleSnapToPoint, setToggleSnapToPoint] = React.useState(false);
+  const [togglePersistOnEnd, setTogglePersistOnEnd] = React.useState(false);
   const [toggleHighlight, setToggleHighlight] = React.useState(false);
 
   const [floatingTooltip, setFloatingTooltip] = React.useState(false);
@@ -169,6 +170,7 @@ export default function App() {
               </LineChart.Path>
               <LineChart.CursorCrosshair
                 snapToPoint={toggleSnapToPoint}
+                persistOnEnd={togglePersistOnEnd}
                 onActivated={invokeHaptic}
                 onEnded={invokeHaptic}
                 at={at}
@@ -320,6 +322,14 @@ export default function App() {
                 >
                   <Text style={styles.buttonText}>
                     Toggle Snap {toggleSnapToPoint ? 'Off' : 'On'}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.button}
+                  onPress={() => setTogglePersistOnEnd((val) => !val)}
+                >
+                  <Text style={styles.buttonText}>
+                    Toggle Persist On End {togglePersistOnEnd ? 'Off' : 'On'}
                   </Text>
                 </TouchableOpacity>
                 <TouchableOpacity

--- a/src/charts/line/Cursor.tsx
+++ b/src/charts/line/Cursor.tsx
@@ -26,6 +26,7 @@ export type LineChartCursorProps = {
   onActivated?: () => void;
   onEnded?: () => void;
   orientation?: 'horizontal' | 'vertical';
+  persistOnEnd?: boolean;
 };
 
 export const CursorContext = React.createContext({ type: '' });
@@ -38,6 +39,7 @@ export function LineChartCursor({
   type,
   at,
   shouldCancelWhenOutside = false,
+  persistOnEnd = false,
   minDurationMs = 0,
   onActivated,
   onEnded,
@@ -149,8 +151,11 @@ export function LineChartCursor({
     })
     .onEnd(() => {
       'worklet';
-      isActive.value = false;
-      currentIndex.value = -1;
+
+      if (!persistOnEnd) {
+        isActive.value = false;
+        currentIndex.value = -1;
+      }
 
       if (onEnded) {
         runOnJS(onEnded)();

--- a/src/charts/line/CursorLine.tsx
+++ b/src/charts/line/CursorLine.tsx
@@ -21,6 +21,7 @@ type LineChartCursorLineProps = {
   lineProps?: Partial<LineProps>;
   format?: TFormatterFn<string | number>;
   textStyle?: TextStyle;
+  persistOnEnd?: boolean;
 } & Omit<LineChartCursorProps, 'type' | 'children'>;
 
 LineChartCursorLine.displayName = 'LineChartCursorLine';


### PR DESCRIPTION
## Summary

- Add a `persistOnEnd` boolean prop to `LineChartCursor` and `LineChartCursorLine` that keeps the cursor active at its last position after the user lifts their finger, instead of resetting
- When `persistOnEnd` is `false` (default), behavior is unchanged — the cursor disappears on gesture end
- When `persistOnEnd` is `true`, `isActive` stays `true` and `currentIndex` is preserved after the gesture ends

## Use case

Useful for charts where you want the cursor to remain pinned on the last touched data point, for example to show a default selection on the most recent value:

```tsx
  <LineChart.CursorCrosshair persistOnEnd at={data.length - 1} />
  <LineChart.CursorLine persistOnEnd at={data.length - 1} />
```

## Test plan

- Open the example app Line Chart screen
- Tap "Toggle Persist On End On"
- Long press on the chart, drag, then release — cursor should stay pinned at last position
- Tap "Toggle Persist On End Off"
- Long press and release — cursor should disappear as before


https://github.com/user-attachments/assets/566c7a9e-a7b2-47e6-b98d-372fca313ed3