### PR TITLE
feat: add showLabel prop to CursorLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,6 +954,7 @@ function in the form of a
 | `color`        | `string`    | `"gray"` | Color of the cursor line                                           |
 | `lineProps`    | `LineProps` |          | Props of the cursor line. Takes React Native SVG's `Line` props.   |
 | `persistOnEnd` | `boolean`   | `false`  | Keep the cursor pinned at its last position after the gesture ends |
+| `showLabel`    | `boolean`   | `true`   | Show the bottom label for timestamp                                |
 | `at`           | `number`    |          | Index of followed `data` item.                                     |
 
 ### LineChart.Dot

--- a/example/src/LineChart.tsx
+++ b/example/src/LineChart.tsx
@@ -61,6 +61,8 @@ export default function App() {
   const [toggleSnapToPoint, setToggleSnapToPoint] = React.useState(false);
   const [togglePersistOnEnd, setTogglePersistOnEnd] = React.useState(false);
   const [toggleHighlight, setToggleHighlight] = React.useState(false);
+  const [toggleShowLabelOnCursorLine, setToggleShowLabelOnCursorLine] =
+    React.useState(true);
 
   const [floatingTooltip, setFloatingTooltip] = React.useState(false);
   const [tooltipPosition, setTooltipPosition] =
@@ -168,6 +170,7 @@ export default function App() {
                   />
                 )}
               </LineChart.Path>
+              <LineChart.CursorLine showLabel={toggleShowLabelOnCursorLine} />
               <LineChart.CursorCrosshair
                 snapToPoint={toggleSnapToPoint}
                 persistOnEnd={togglePersistOnEnd}
@@ -330,6 +333,15 @@ export default function App() {
                 >
                   <Text style={styles.buttonText}>
                     Toggle Persist On End {togglePersistOnEnd ? 'Off' : 'On'}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.button}
+                  onPress={() => setToggleShowLabelOnCursorLine((val) => !val)}
+                >
+                  <Text style={styles.buttonText}>
+                    Toggle Show Label On CusorLine{' '}
+                    {toggleShowLabelOnCursorLine ? 'On' : 'Off'}
                   </Text>
                 </TouchableOpacity>
                 <TouchableOpacity

--- a/src/charts/line/CursorLine.tsx
+++ b/src/charts/line/CursorLine.tsx
@@ -18,6 +18,7 @@ import { useLineChartPrice } from './usePrice';
 type LineChartCursorLineProps = {
   children?: React.ReactNode;
   color?: string;
+  showLabel?: boolean;
   lineProps?: Partial<LineProps>;
   format?: TFormatterFn<string | number>;
   textStyle?: TextStyle;
@@ -48,6 +49,7 @@ const AnimatedLine = Animated.createAnimatedComponent(SVGLine);
 export function LineChartCursorLine({
   children,
   color = 'gray',
+  showLabel = true,
   lineProps,
   format,
   textStyle,
@@ -105,7 +107,7 @@ export function LineChartCursorLine({
     if (isHorizontal) return 0;
 
     // For vertical cursor, extend line to the chart area (excluding reserved label space)
-    return height - SPACING.X_AXIS_LABEL_RESERVED_HEIGHT;
+    return showLabel ? height - SPACING.X_AXIS_LABEL_RESERVED_HEIGHT : height;
   });
 
   const containerStyle = useAnimatedStyle(() => ({
@@ -208,7 +210,9 @@ export function LineChartCursorLine({
             {...lineProps}
           />
         </Svg>
-        <AnimatedText text={displayText} style={textPositionStyle} />
+        {showLabel && (
+          <AnimatedText text={displayText} style={textPositionStyle} />
+        )}
       </Animated.View>
       {children}
     </LineChartCursor>


### PR DESCRIPTION
## Summary  

- Add a `showLabel` boolean prop to enable show timestamp text on LineChart.CursorLine or not
- When `showLabel` is true (default), behavior is unchanged — the timestamp text will shown on the bottom of cursorLine
- When `showLabel` is false, no text will shown on the bottom of cursor line and the cursor line will be extended to the bottom

https://github.com/user-attachments/assets/afff8a52-f96c-42e6-a792-31bfd751fb88


