### PR TITLE
fix: HorizontalLine positioning when using at={{ value }} prop

### DIFF
--- a/src/charts/line/HorizontalLine.tsx
+++ b/src/charts/line/HorizontalLine.tsx
@@ -55,6 +55,9 @@ export function LineChartHorizontalLine({
   );
   const { yDomain } = useLineChart();
 
+  // Reserve space at the bottom for x-axis cursor labels
+  const X_AXIS_LABEL_RESERVED_HEIGHT = 40;
+
   const y = useDerivedValue(() => {
     if (typeof at === 'number' || at.index != null) {
       const index = typeof at === 'number' ? at : at.index;
@@ -74,7 +77,8 @@ export function LineChartHorizontalLine({
 
     const offsetTop = yDomain.max - at.value;
     const percentageOffsetTop = offsetTop / (yDomain.max - yDomain.min);
-    const heightBetweenGutters = height - gutter * 2;
+    const chartDrawingHeight = height - X_AXIS_LABEL_RESERVED_HEIGHT;
+    const heightBetweenGutters = chartDrawingHeight - gutter * 2;
     const offsetTopPixels = gutter + percentageOffsetTop * heightBetweenGutters;
 
     return withTiming(offsetTopPixels + offsetY);


### PR DESCRIPTION
## Problem

`LineChart.HorizontalLine` with `at={{ value }}` renders below the desired position.

Values within the y-domain appear outside the chart area.

## Cause

[`Chart.tsx#L56`](https://github.com/coinjar/react-native-wagmi-charts/blob/master/src/charts/line/Chart.tsx#L56) reserves 40px and draws the path using `height - 40`.

But [`HorizontalLine.tsx#L77`](https://github.com/coinjar/react-native-wagmi-charts/blob/master/src/charts/line/HorizontalLine.tsx#L77) uses the full `height` from context.


## Fix

```diff
// HorizontalLine.tsx

+ const X_AXIS_LABEL_RESERVED_HEIGHT = 40;

// inside useDerivedValue, around line 75:
+ const chartDrawingHeight = height - X_AXIS_LABEL_RESERVED_HEIGHT;
- const heightBetweenGutters = height - gutter * 2;
+ const heightBetweenGutters = chartDrawingHeight - gutter * 2;
```
